### PR TITLE
Protect against edge cases that crash the native bindings of `bigint-buffer`

### DIFF
--- a/src/bigint.ts
+++ b/src/bigint.ts
@@ -3,9 +3,15 @@ import { blob, Layout } from '@solana/buffer-layout';
 import { toBigIntBE, toBigIntLE, toBufferBE, toBufferLE } from 'bigint-buffer';
 import { encodeDecode } from './base';
 
-export const bigInt =
-    (length: number) =>
-    (property?: string): Layout<bigint> => {
+// https://github.com/no2chem/bigint-buffer/issues/59
+function assertValidBigInteger(untrustedInput: unknown): asserts untrustedInput is bigint {
+    if (typeof untrustedInput !== 'bigint') {
+        throw new Error('Expected a `BigInt`');
+    }
+}
+
+function bigInt_IMPL(littleEndian: boolean, length: number) {
+    return (property?: string): Layout<bigint> => {
         const layout = blob(length, property);
         const { encode, decode } = encodeDecode(layout);
 
@@ -13,50 +19,42 @@ export const bigInt =
 
         bigIntLayout.decode = (buffer: Buffer, offset: number) => {
             const src = decode(buffer, offset);
-            return toBigIntLE(Buffer.from(src));
+            return littleEndian ? toBigIntLE(Buffer.from(src)) : toBigIntBE(Buffer.from(src));
         };
 
         bigIntLayout.encode = (bigInt: bigint, buffer: Buffer, offset: number) => {
-            const src = toBufferLE(bigInt, length);
+            assertValidBigInteger(bigInt);
+            let src;
+            if (length === 0) {
+                // https://github.com/no2chem/bigint-buffer/issues/40
+                // `toBuffer{BE|LE}` crashes when passed zero for the `length` argument.
+                src = Buffer.alloc(0);
+            } else {
+                src = littleEndian ? toBufferLE(bigInt, length) : toBufferBE(bigInt, length);
+            }
             return encode(src, buffer, offset);
         };
 
         return bigIntLayout;
     };
+}
 
-export const bigIntBE =
-    (length: number) =>
-    (property?: string): Layout<bigint> => {
-        const layout = blob(length, property);
-        const { encode, decode } = encodeDecode(layout);
+export const bigInt = /* @__PURE__ */ bigInt_IMPL.bind(null, /* littleEndian */ true);
 
-        const bigIntLayout = layout as Layout<unknown> as Layout<bigint>;
+export const bigIntBE = /* @__PURE__ */ bigInt_IMPL.bind(null, /* littleEndian */ false);
 
-        bigIntLayout.decode = (buffer: Buffer, offset: number) => {
-            const src = decode(buffer, offset);
-            return toBigIntBE(Buffer.from(src));
-        };
+export const u64 = /* @__PURE__ */ bigInt(8);
 
-        bigIntLayout.encode = (bigInt: bigint, buffer: Buffer, offset: number) => {
-            const src = toBufferBE(bigInt, length);
-            return encode(src, buffer, offset);
-        };
+export const u64be = /* @__PURE__ */ bigIntBE(8);
 
-        return bigIntLayout;
-    };
+export const u128 = /* @__PURE__ */ bigInt(16);
 
-export const u64 = bigInt(8);
+export const u128be = /* @__PURE__ */ bigIntBE(16);
 
-export const u64be = bigIntBE(8);
+export const u192 = /* @__PURE__ */ bigInt(24);
 
-export const u128 = bigInt(16);
+export const u192be = /* @__PURE__ */ bigIntBE(24);
 
-export const u128be = bigIntBE(16);
+export const u256 = /* @__PURE__ */ bigInt(32);
 
-export const u192 = bigInt(24);
-
-export const u192be = bigIntBE(24);
-
-export const u256 = bigInt(32);
-
-export const u256be = bigIntBE(32);
+export const u256be = /* @__PURE__ */ bigIntBE(32);


### PR DESCRIPTION
When the C bindings of `bigint-buffer` are in play…

Crashes that this PR prevents:

```
// Zero length
import { toBufferLE } from 'bigint-buffer';
toBufferLE(1n, /* length */ 0); // CRASH
```

```
// Non-bigint
import { bigInt } from '@solana/buffer-layout-utils';
const buf = Buffer.alloc(8);
bigInt(8)().encode(255n, buf, 0); // OK
bigInt(8)().encode(255, buf, 0); // CRASH
bigInt(8)().encode(true, buf, 0); // CRASH
bigInt(8)().encode(false, buf, 0); // CRASH
bigInt(8)().encode({}, buf, 0); // CRASH
bigInt(8)().encode([], buf, 0); // CRASH
bigInt(8)().encode(null, buf, 0); // CRASH
bigInt(8)().encode(undefined, buf, 0); // CRASH
```
